### PR TITLE
[fix]: pin rabbitmq image to 4.0.5-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     <<: *redishealthcheck
 
   txs-rabbitmq:
-    image: rabbitmq:alpine
+    image: rabbitmq:4.0.5-alpine
 
   txs-worker-indexer: &txs-worker
     image: gulabs/safe-transaction-service:${TXS_VERSION}
@@ -172,7 +172,7 @@ services:
       - 8080
 
   general-rabbitmq:
-    image: rabbitmq:alpine
+    image: rabbitmq:4.0.5-alpine
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 15s


### PR DESCRIPTION

## Summary
Prevent rabbitmq from auto-upgrading to latest via floating alpine tag.

Fixes #(issue)

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring
- [ ] 🧪 Test update

## Testing
<!-- How was this tested? -->
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Screenshots (if UI change)
| Before | After |
|--------|-------|
|        |       |

## Checklist
- [ ] Self-reviewed my code
- [ ] Added/updated tests
- [ ] Updated documentation (if needed)
- [ ] No new warnings
